### PR TITLE
Removing promote and sticky options for content editor role

### DIFF
--- a/publishing_workflow/publishing_workflow.module
+++ b/publishing_workflow/publishing_workflow.module
@@ -36,6 +36,12 @@ function publishing_workflow_form_alter(&$form, &$form_state, $form_id) {
       	$status = $is_portal_admin || $is_editor || $is_administrator ? 1 : 0;
         $form['options']['status']['#default_value'] = $status;
       }
+      
+      // Hide promote and sticky options for content editor.
+      if ($is_editor) {
+        $form['options']['promote']['#type'] = 'hidden';
+        $form['options']['sticky']['#type'] = 'hidden';
+      }
       break;
   }
 }


### PR DESCRIPTION
Issue NuCivic/nucivic-internal#148
### Acceptance Test

content editor should not have **promoted** and **sticky** options for datasets and resources
