### PR TITLE
Portal Admin can only edit main-menu

### DIFF
--- a/data_workflow.make
+++ b/data_workflow.make
@@ -13,6 +13,9 @@ projects[entityreference_unpublished_node][type] = module
 projects[features_roles_permissions][version] = 1.0
 projects[features_roles_permissions][subdir] = contrib
 
+projects[menu_admin_per_menu][version] = 1.0
+projects[menu_admin_per_menu][subdir] = contrib
+
 projects[roleassign][version] = 1.0
 projects[roleassign][subdir] = contrib
 

--- a/publishing_roles/portal_administrator_role/portal_administrator_role.features.roles_permissions.inc
+++ b/publishing_roles/portal_administrator_role/portal_administrator_role.features.roles_permissions.inc
@@ -21,7 +21,7 @@ function portal_administrator_role_default_roles_permissions() {
       'access content overview' => TRUE,
       'access unpublished data' => TRUE,
       'access user profiles' => TRUE,
-      'administer menu' => TRUE,
+      'administer main-menu menu items' => TRUE,
       'administer nodes' => TRUE,
       'administer taxonomy' => TRUE,
       'administer users' => TRUE,

--- a/publishing_roles/portal_administrator_role/portal_administrator_role.info
+++ b/publishing_roles/portal_administrator_role/portal_administrator_role.info
@@ -9,6 +9,7 @@ dependencies[] = dkan_dataset
 dependencies[] = entityreference_unpublished_node
 dependencies[] = features
 dependencies[] = features_roles_permissions
+dependencies[] = menu_admin_per_menu
 dependencies[] = role_delegation
 dependencies[] = role_export
 dependencies[] = roleassign

--- a/publishing_roles/portal_administrator_role/portal_administrator_role.module
+++ b/publishing_roles/portal_administrator_role/portal_administrator_role.module
@@ -35,13 +35,13 @@ function portal_administrator_role_menu_alter(&$items) {
  * Implements hook_modules_enabled().
  */
 function portal_administrator_role_modules_enabled($modules) {
-  if (in_array($modules, 'data_story_storyteller_role')) {
+  if (in_array('data_story_storyteller_role', $modules)) {
     user_role_grant_permissions(
       PORTAL_ADMINISTRATOR_ROLE_RID,
       array('assign storyteller role')
     );
   }
-  if (in_array($modules, 'data_story')) {
+  if (in_array('data_story', $modules)) {
     user_role_grant_permissions(
       PORTAL_ADMINISTRATOR_ROLE_RID,
       array(


### PR DESCRIPTION
NuCivic/nucivic-internal#146: Limit portal admin role to edit main-menu only

Logged as a portal administrator i should only be able to edit the main-menu
