### PR TITLE
Migrate all dkan editors when enabling publishing_workflow

### DIFF
--- a/publishing_workflow/publishing_workflow.install
+++ b/publishing_workflow/publishing_workflow.install
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @file
+ * Installation procedures for publishing_workflow
+ */
+
+/**
+ * Implements hook_enable().
+ */
+function publishing_workflow_enable() {
+  // Migrate all editors to content editors.
+  $editor_role = user_role_load_by_name('editor');
+  $content_editor_role = user_role_load_by_name('content editor');
+  $editors_query =  db_select('users_roles', 'ur')
+                 ->fields('ur', array('uid'))
+                 ->condition('rid', $editor_role->rid)
+                 ->execute();
+  $editors = array();
+  foreach ($editors_query as $editor) {
+    array_push($editors, $editor->uid);
+  }
+  user_multiple_role_edit($editors, 'add_role', $content_editor_role->rid);
+  user_multiple_role_edit($editors, 'remove_role', $editor_role->rid);
+  // Disable dkan_sitewide_roles_perms if enabled.
+  if (module_exists('dkan_sitewide_roles_perms')) {
+    module_disable(array('dkan_sitewide_roles_perms'));
+    drupal_uninstall_modules(array('dkan_sitewide_roles_perms'));
+  }
+  // Delete editor role
+  user_role_delete($editor_role);
+}


### PR DESCRIPTION
NuCivic/nucivic-internal#88: Migrate all dkan editors to content editors when enabling publishing_workflow
