### PR TITLE
Only send notice to editor's that have access to the node being created by data contributor

### DIFF
--- a/publishing_workflow/publishing_workflow.module
+++ b/publishing_workflow/publishing_workflow.module
@@ -45,3 +45,41 @@ function publishing_workflow_form_alter(&$form, &$form_state, $form_id) {
       break;
   }
 }
+/**
+ * Implements hook_rules_action_info().
+ */
+function publishing_workflow_rules_action_info() {
+  $items = array();
+  $items['publishing_workflow_reviewers'] = array(
+    'label' => t('Get reviewers for a specific node'),
+    'group' => t('Data Workflow'),
+    'parameter' => array(
+        'node' => array('type' => 'node', 'label' => t('Node')),
+    ),
+    'provides' => array(
+      'reviewers' => array('type' => 'list<user>', 'label' => t('List of reviewers')),
+    ),
+  );
+  return $items;
+}
+
+/**
+ * Returns a list of content editors that have access to the node being edited.
+ */
+function publishing_workflow_reviewers($node){
+  $reviewers = array();
+  $content_editor_role = user_role_load_by_name('content editor');
+  $editors_query =  db_select('users_roles', 'ur')
+                 ->fields('ur', array('uid'))
+                 ->condition('rid', $content_editor_role->rid)
+                 ->execute();
+  foreach ($editors_query as $editor) {
+    $editor = user_load($editor->uid);
+    $has_access = og_node_access('update', $node, $editor);
+    $has_access = $has_access || node_access('update', $node, $editor);
+    if ($has_access) {
+      array_push($reviewers, $editor);
+    }
+  }
+  return array('reviewers' => $reviewers);
+}

--- a/publishing_workflow/publishing_workflow.rules_defaults.inc
+++ b/publishing_workflow/publishing_workflow.rules_defaults.inc
@@ -13,7 +13,7 @@ function publishing_workflow_default_rules_configuration() {
       "LABEL" : "NUCIVIC DATA -Author saves Dataset or Resource",
       "PLUGIN" : "reaction rule",
       "TAGS" : [ "author", "dataset", "resource" ],
-      "REQUIRES" : [ "rules" ],
+      "REQUIRES" : [ "rules", "publishing_workflow" ],
       "ON" : [ "node_insert", "node_update" ],
       "IF" : [
         { "node_is_of_type" : {
@@ -29,11 +29,24 @@ function publishing_workflow_default_rules_configuration() {
         }
       ],
       "DO" : [
-        { "mail_to_users_of_role" : {
-            "roles" : { "value" : { "254633039" : "254633039" } },
-            "subject" : "[node:author] has just updated [node:title] on ",
-            "message" : "Please review the recent update at [node:title] -\\u003E [node:edit-url]",
-            "from" : "[site:mail]"
+        { "publishing_workflow_reviewers" : {
+            "USING" : { "node" : [ "node" ] },
+            "PROVIDE" : { "reviewers" : { "reviewers" : "List of reviewers" } }
+          }
+        },
+        { "LOOP" : {
+            "USING" : { "list" : [ "reviewers" ] },
+            "ITEM" : { "list_item" : "Current list item" },
+            "DO" : [
+              { "mail" : {
+                  "to" : [ "list-item:mail" ],
+                  "subject" : "[node:author] has just updated \\u0022[node:title]\\u0022",
+                  "message" : "Please review the recent update at -\\u003E [node:edit-url]",
+                  "from" : "[node:author:mail]",
+                  "language" : [ "" ]
+                }
+              }
+            ]
           }
         }
       ]
@@ -44,7 +57,7 @@ function publishing_workflow_default_rules_configuration() {
       "PLUGIN" : "reaction rule",
       "TAGS" : [ "dataset", "editor", "publish", "resource" ],
       "REQUIRES" : [ "rules" ],
-      "ON" : [ "node_update", "node_insert" ],
+      "ON" : [ "node_update" ],
       "IF" : [
         { "node_is_of_type" : {
             "node" : [ "node" ],
@@ -62,7 +75,7 @@ function publishing_workflow_default_rules_configuration() {
         { "mail" : {
             "to" : "[node:author:mail]",
             "subject" : "The \\u0022[node:title]\\u0022 [node:content-type] was just published",
-            "message" : "You can review it here -\\u003E [node:url]",
+            "message" : "You can review it here -\\u003E [node:edit-url]",
             "from" : "[site:mail]",
             "language" : [ "" ]
           }


### PR DESCRIPTION
NuCivic/nucivic-internal#90:
- Custom action to get a list of content editors that have access to a
  node.
- Updated rule with a loop to send email to the list provided by the
  above.
