### PR TITLE
Update data_workflow.make

### DIFF
--- a/data_workflow.make
+++ b/data_workflow.make
@@ -1,10 +1,6 @@
 core = 7.x
 api = 2
 
-; Adds the ability to add og roles to user with rules
-;projects[og][version] = 2.7
-;projects[og][subdir] = contrib
-
 projects[entityreference_unpublished_node][download][type] = git
 projects[entityreference_unpublished_node][download][url] = "http://git.drupal.org/sandbox/Ayrmax/1977458.git"
 projects[entityreference_unpublished_node][subdir] = contrib
@@ -36,6 +32,7 @@ projects[workbench][subdir] = contrib
 projects[workbench_moderation][version] = 1.4
 projects[workbench_moderation][subdir] = contrib
 projects[workbench_moderation][patch][2393771] = https://www.drupal.org/files/issues/specify_change_state_user-2393771-5.patch
+projects[workbench_moderation][patch][1838640] = https://www.drupal.org/files/issues/workbench_moderation-fix_callback_argument-1838640-23.patch
 
 projects[workbench_email][version] = 3.3
 projects[workbench_email][subdir] = contrib


### PR DESCRIPTION
This fixes a whitescreen for moderated content on node/NID/draft when restws is enabled.

Ref: https://github.com/NuCivic/internal/issues/649