### PR TITLE
[411-healthdata] Security update for workbench_email.

### DIFF
--- a/data_workflow.make
+++ b/data_workflow.make
@@ -33,7 +33,7 @@ projects[workbench_moderation][version] = 1.4
 projects[workbench_moderation][subdir] = contrib
 projects[workbench_moderation][patch][2393771] = https://www.drupal.org/files/issues/specify_change_state_user-2393771-5.patch
 
-projects[workbench_email][version] = 3.3
+projects[workbench_email][version] = 3.4
 projects[workbench_email][subdir] = contrib
 projects[workbench_email][patch][2391233] = https://www.drupal.org/files/issues/workbench_email-2391233-3.patch
 projects[workbench_email][patch][2529016] = https://www.drupal.org/files/issues/workbench_email-skip_filter_anonymous-2529016.patch


### PR DESCRIPTION
Capture the security update for the workbench_email module.

Refs: 
https://github.com/NuCivic/healthdata/issues/411
- Acceptance:
- [ ] 3.4 module is referenced in data_workflow.build.
